### PR TITLE
feat: Format calls to error_logger:*_msg(...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project should be added as a dependency to your project
       ,[ { handler
          , default
          , logger_std_h
-         , #{formatter => {jsonformat, #{}}}
+         , #{formatter => {jsonformat, #{new_line => true}}}
          }
        ] }
     , {logger_level, info}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This project should be added as a dependency to your project
 
 ```erlang
 [ { kernel
-  , {logger_level, info}
   , [ { logger
       ,[ { handler
          , default
@@ -20,6 +19,7 @@ This project should be added as a dependency to your project
          , #{formatter => {jsonformat, #{}}}
          }
        ] }
+    , {logger_level, info}
    ] }
 ].
 

--- a/config/sys.config
+++ b/config/sys.config
@@ -20,7 +20,7 @@
       , [ { handler
           , default
           , logger_std_h
-          , #{formatter => {jsonformat, #{}}}
+          , #{formatter => {jsonformat, #{new_line => true}}}
           }
         ] }
     , {logger_level, info}

--- a/src/jsonformat.app.src
+++ b/src/jsonformat.app.src
@@ -15,7 +15,7 @@
 {application, jsonformat,
   [ {description,  "A custom formatter for the erlang logger applications that "
                    "outputs JSON formatted single line logs"}
-  , {vsn,           "0.0.1"}
+  , {vsn,           "1.0.1"}
   , {modules,      []}
   , {registered,   []}
   , {applications, [ kernel

--- a/src/jsonformat.app.src
+++ b/src/jsonformat.app.src
@@ -20,6 +20,7 @@
   , {registered,   []}
   , {applications, [ kernel
                    , stdlib
+                   , jsx
                    ]}
   , {licenses,     ["MIT"]}
   , {links,        [{"Github", "https://github.com/kivra/jsonformat/"}]}

--- a/src/jsonformat.erl
+++ b/src/jsonformat.erl
@@ -27,6 +27,8 @@
 %%%_* Code =============================================================
 %%%_ * API -------------------------------------------------------------
 -spec format(logger:log_event(), logger:formatter_config()) -> unicode:chardata().
+format(#{msg:={report, #{format:=Format, args:=Args, label:={error_logger, _}}}} = Map, Config) ->
+  format(Map#{msg := {report, #{text => io_lib:format(Format, Args)}}}, Config);
 format(#{level:=Level, msg:={report, Msg}, meta:=Meta}, Config) when is_map(Msg) ->
   encode(pre_encode(maps:merge(Msg, maps:put(level, Level, Meta)), Config));
 format(Map = #{msg := {report, KeyVal}}, Config) when is_list(KeyVal) ->

--- a/src/jsonformat.erl
+++ b/src/jsonformat.erl
@@ -30,7 +30,7 @@
 format(#{msg:={report, #{format:=Format, args:=Args, label:={error_logger, _}}}} = Map, Config) ->
   format(Map#{msg := {report, #{text => io_lib:format(Format, Args)}}}, Config);
 format(#{level:=Level, msg:={report, Msg}, meta:=Meta}, Config) when is_map(Msg) ->
-  encode(pre_encode(maps:merge(Msg, maps:put(level, Level, Meta)), Config));
+  encode(pre_encode(maps:merge(Msg, maps:put(level, Level, Meta)), Config), Config);
 format(Map = #{msg := {report, KeyVal}}, Config) when is_list(KeyVal) ->
   format(Map#{msg := {report, maps:from_list(KeyVal)}}, Config);
 format(Map = #{msg := {string, String}}, Config) ->
@@ -49,8 +49,12 @@ pre_encode(Data, Config) ->
     maps:new(),
     Data).
 
-encode(Data) ->
-  jsx:encode(Data).
+encode(Data, Config) ->
+  Json = jsx:encode(Data),
+  case maps:get(new_line, Config, false) of
+    true -> [Json, <<"\n">>];
+    false -> Json
+  end.
 
 jsonify(A) when is_atom(A)     -> A;
 jsonify(B) when is_binary(B)   -> B;


### PR DESCRIPTION
When calling error_logger:*_msg(..) the format and args were logged. With this change, they are logged similarly to how eg logger:info(...) calls are logged.

With this change:
```erl
1>  error_logger:info_msg("hej ~s", ["Kivra"]).
{"error_logger":{"tag":"info_msg"},"gl":"<0.65.0>","level":"notice","pid":"<0.83.0>","report_cb":"#Fun<error_logger.0.132682287>","text":"hej Kivra","time":1618311723873002}
```

Before this change:
```erl
1>  error_logger:info_msg("hej ~s", ["Kivra"]).
{"args":"Kivra","error_logger":{"tag":"info_msg"},"format":"hej ~s","gl":"<0.65.0>","label":"{error_logger,info_msg}","level":"notice","pid":"<0.83.0>","report_cb":"#Fun<error_logger.0.132682287>","time":1618311978975412}
```

This PR identifies error_logger messages the same way as flatlog: https://github.com/ferd/flatlog/blob/1168e0a265f437d62a63262c385e7379ad28d38a/src/flatlog.erl#L26