### PR TITLE
feat: Allow key mapping via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,31 @@ This project should be added as a dependency to your project
 {"a":"b","gl":"<0.178.0>","level":"info","pid":"<0.182.0>","report_cb":"fun logger:format_otp_report/1","time":1585902924341139}ok
 ```
 
+### Configuration Options
+To print each json object to a new line, set `new_line` to `true`:
+
+```erlang
+#{formatter => {jsonformat, #{ new_line => true }}}
+```
+
+To rename keys in the resulting json object, provide a `key_mapping`. For
+example, to rename the `time` and `level` keys to `timestamp` and `lvl`
+respectively, use:
+
+```erlang
+#{formatter => {jsonformat, #{ key_mapping => #{ time => timestamp
+                                               , level => lvl }}}}
+```
+
+To format values in the resulting json object, provide a map of `format_funs`.
+For example, to format the value associated with the `time` key, use:
+
+```erlang
+#{formatter => {jsonformat, #{ format_funs => #{ time => fun(T) -> ... end }}}
+```
+
+Note that `key_mapping`s are applied before `format_funs`.
+
 ## Running the tests
 
 ```

--- a/src/jsonformat.erl
+++ b/src/jsonformat.erl
@@ -44,7 +44,7 @@ format(#{msg:={report, #{format:=Format, args:=Args, label:={error_logger, _}}}}
 format(#{level:=Level, msg:={report, Msg}, meta:=Meta}, Config) when is_map(Msg) ->
   Data0 = maps:merge(Msg, Meta#{level => Level}),
   Data1 = apply_key_mapping(Data0, Config),
-  Data2 = format_data(Data1, Config),
+  Data2 = apply_format_funs(Data1, Config),
   encode(pre_encode(Data2, Config), Config);
 format(Map = #{msg := {report, KeyVal}}, Config) when is_list(KeyVal) ->
   format(Map#{msg := {report, maps:from_list(KeyVal)}}, Config);
@@ -92,11 +92,11 @@ jsonify(Any)                   -> unicode:characters_to_binary(io_lib:format("~w
 
 a2b(A) -> atom_to_binary(A, utf8).
 
-format_data(Data, #{format_funs := Callbacks}) ->
+apply_format_funs(Data, #{format_funs := Callbacks}) ->
   maps:fold(fun(K, Fun, Acc) when is_map_key(K, Data) -> maps:update_with(K, Fun, Acc);
                (_, _, Acc)                            -> Acc
             end, Data, Callbacks);
-format_data(Data, _) ->
+apply_format_funs(Data, _) ->
   Data.
 
 apply_key_mapping(Data, #{key_mapping := Mapping}) ->


### PR DESCRIPTION
## About
Sorry, there's been a bit of back-and-forth, but I think this ⬇️ makes for a much nicer API 🙂 

This PR extends the existing functionality to rename keys in the resulting json object. At the moment, only the `text` key can be renamed via the `text_output_key` config parameter. This PR introduces a `key_mapping` config parameter that allows to rename keys freely:

```erlang
  Config = #{ key_mapping => #{ time => timestamp
                              , level => lvl }
            , format_funs => #{ timestamp => fun(T) -> ... end}},
```

The `key_mapping` is applied before `format_funs` are applied. This is a breaking change since the `text_output_key` config parameter is no longer supported.