### PR TITLE
feat: Handle error_logger:error_report and proc_lib crash messages

### DIFF
--- a/src/jsonformat.erl
+++ b/src/jsonformat.erl
@@ -84,7 +84,7 @@ jsonify(L) when is_list(L)     ->
   try list_to_binary(L) of
     S -> S
   catch error:badarg ->
-    unicode:characters_to_binary(io_lib:format("~w", [L]))
+    unicode:characters_to_binary(io_lib:format("~0p", [L]))
   end;
 jsonify({M, F, A}) when is_atom(M), is_atom(F), is_integer(A) ->
   <<(a2b(M))/binary,$:,(a2b(F))/binary,$/,(integer_to_binary(A))/binary>>;
@@ -137,7 +137,7 @@ key_mapping_test() ->
                               , text => message}},
   ?assertEqual( <<"{\"lvl\":\"alert\",\"message\":\"derp\"}">>
               , format(#{level => alert, msg => {string, "derp"}, meta => #{}}, Config1)),
-  
+
   Config2 = #{key_mapping => #{ level => lvl
                               , text => level}},
   ?assertEqual( <<"{\"level\":\"derp\",\"lvl\":\"alert\"}">>
@@ -147,12 +147,20 @@ key_mapping_test() ->
                               , foobar => level}},
   ?assertEqual( <<"{\"lvl\":\"alert\",\"text\":\"derp\"}">>
               , format(#{level => alert, msg => {string, "derp"}, meta => #{}}, Config3)),
-  
+
   Config4 = #{ key_mapping => #{time => timestamp}
              , format_funs => #{timestamp => fun(T) -> T + 1 end}},
   ?assertEqual( <<"{\"level\":\"alert\",\"text\":\"derp\",\"timestamp\":2}">>
               , format(#{level => alert, msg => {string, "derp"}, meta => #{time => 1}}, Config4)).
-           
+
+list_format_test() ->
+    ErrorReport =
+        #{level => error,
+          meta => #{time => 1},
+          msg => {report,#{report => [{hej,"hopp"}]}}},
+    ?assertEqual( <<"{\"level\":\"error\",\"report\":\"[{hej,\\\"hopp\\\"}]\",\"time\":1}">>
+                , format(ErrorReport, #{})).
+
 -endif.
 
 %%%_* Emacs ============================================================


### PR DESCRIPTION
Hello,

error_reports and crash messages from proc_lib:spawn(...) in not formatted in a nice way.

Currently:
```erlang
> error_logger:error_report([{hej,"hopp"}, {bla,"blo"}]).
{"error_logger":{"tag":"error_report","type":"std_error"},"gl":"<0.148.0>","label":"{error_logger,error_report}","level":"error","pid":"<0.152.0>","report":"[{hej,[104,111,112,112]},{bla,[98,108,111]}]","report_cb":"#Fun<error_logger.0.132682287>","time":1619015477151977}

> proc_lib:spawn(fun() -> error(bad) end).
{"domain":"[otp,sasl]","error_logger":{"tag":"error_report","type":"crash_report"},"file":"proc_lib.erl","gl":"<0.148.0>","label":"{proc_lib,crash}","level":"error","line":508,"logger_formatter":{"title":"CRASH REPORT"},"mfa":"proc_lib:crash_report/4","pid":"<0.172.0>","report":"[[{initial_call,{erl_eval,'-expr/5-fun-3-',[]}},{pid,<0.172.0>},{registered_name,[]},{error_info,{error,bad,[{shell,apply_fun,3,[{file,[115,104,101,108,108,46,101,114,108]},{line,904}]},{proc_lib,init_p,3,[{file,[112,114,111,99,95,108,105,98,46,101,114,108]},{line,234}]}]}},{ancestors,[<0.152.0>]},{message_queue_len,0},{messages,[]},{links,[]},{dictionary,[]},{trap_exit,false},{status,running},{heap_size,233},{stack_size,27},{reductions,203}],[]]","report_cb":"fun proc_lib:report_cb/2","time":1619015549519999}
```

With this PR:
```erlang
> error_logger:error_report([{hej,"hopp"}, {bla,"blo"}]).
{"error_logger":{"tag":"error_report","type":"std_error"},"gl":"<0.148.0>","level":"error","pid":"<0.152.0>","report_cb":"#Fun<error_logger.0.132682287>","text":"#{label => {error_logger,error_report},report => [{hej,\"hopp\"},{bla,\"blo\"}]}","time":1619015717008800}

> proc_lib:spawn(fun() -> error(bad) end).
{"domain":"[otp,sasl]","error_logger":{"tag":"error_report","type":"crash_report"},"file":"proc_lib.erl","gl":"<0.148.0>","level":"error","line":508,"logger_formatter":{"title":"CRASH REPORT"},"mfa":"proc_lib:crash_report/4","pid":"<0.169.0>","report_cb":"fun proc_lib:report_cb/2","text":"#{label => {proc_lib,crash},report => [[{initial_call,{erl_eval,'-expr/5-fun-3-',[]}},{pid,<0.169.0>},{registered_name,[]},{error_info,{error,bad,[{shell,apply_fun,3,[{file,\"shell.erl\"},{line,904}]},{proc_lib,init_p,3,[{file,\"proc_lib.erl\"},{line,234}]}]}},{ancestors,[<0.152.0>]},{message_queue_len,0},{messages,[]},{links,[]},{dictionary,[]},{trap_exit,false},{status,running},{heap_size,233},{stack_size,27},{reductions,203}],[]]}","time":1619015749312591}