### PR TITLE
feat: config to opt in/out from meta fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ To print each json object to a new line, set `new_line` to `true`:
 #{formatter => {jsonformat, #{ new_line => true }}}
 ```
 
+To control what is being included in the log object from the metadata, there
+are two ways. One can opt-out from fields. Default opts out is `[report_cb]`.
+
+    #{ meta_without => [report_cb, gl, file, domain] }
+
+Or for very detailed control there is instead opt-in.
+
+    #{ meta_with => [time, mfa, line, user_key, client_key] }
+
 To rename keys in the resulting json object, provide a `key_mapping`. For
 example, to rename the `time` and `level` keys to `timestamp` and `lvl`
 respectively, use:

--- a/src/jsonformat.erl
+++ b/src/jsonformat.erl
@@ -43,7 +43,7 @@ format(#{msg:={report, #{format:=Format, args:=Args, label:={error_logger, _}}}}
   Report = #{text => io_lib:format(Format, Args)},
   format(Map#{msg := {report, Report}}, Config);
 format(#{level:=Level, msg:={report, Msg}, meta:=Meta}, Config) when is_map(Msg) ->
-  Data0 = maps:merge(Msg, Meta#{level => Level}),
+  Data0 = merge_meta(Msg, Meta#{level => Level}, Config),
   Data1 = apply_key_mapping(Data0, Config),
   Data2 = apply_format_funs(Data1, Config),
   encode(pre_encode(Data2, Config), Config);
@@ -74,6 +74,9 @@ pre_encode(Data, Config) ->
     end,
     maps:new(),
     Data).
+
+merge_meta(Msg, Meta, _Config) ->
+  maps:merge(Msg, Meta).
 
 encode(Data, Config) ->
   Json = jsx:encode(Data),


### PR DESCRIPTION
`meta_without`

A way to opt-out of fields from the meta object. A list of field names (often atoms). Default excludes report_cb

`meta_with`

A way to opt-in of fields from the meta object. A list of field names (often atoms). Default is all fields remaining after opt-out.