### PR TITLE
feat: deal with lists of maps for nested json

### DIFF
--- a/src/jsonformat.erl
+++ b/src/jsonformat.erl
@@ -69,6 +69,8 @@ pre_encode(Data, Config) ->
   maps:fold(
     fun(K, V, Acc) when is_map(V) ->
       maps:put(jsonify(K), pre_encode(V, Config), Acc);
+       (K, Vs, Acc) when is_list(Vs), is_map(hd(Vs)) -> % assume list of maps
+      maps:put(jsonify(K), [pre_encode(V, Config) || V <- Vs], Acc);
        (K, V, Acc) ->
       maps:put(jsonify(K), jsonify(V), Acc)
     end,

--- a/src/jsonformat.erl
+++ b/src/jsonformat.erl
@@ -70,7 +70,7 @@ pre_encode(Data, Config) ->
     fun(K, V, Acc) when is_map(V) ->
       maps:put(jsonify(K), pre_encode(V, Config), Acc);
        (K, Vs, Acc) when is_list(Vs), is_map(hd(Vs)) -> % assume list of maps
-      maps:put(jsonify(K), [pre_encode(V, Config) || V <- Vs], Acc);
+      maps:put(jsonify(K), [pre_encode(V, Config) || V <- Vs, is_map(V)], Acc);
        (K, V, Acc) ->
       maps:put(jsonify(K), jsonify(V), Acc)
     end,


### PR DESCRIPTION
Allows `#{a => [#{b => 1}, #{b => 2} ` to be logged as `{ "a": [{"b": 1}, {"b": 2}]}`