### PR TITLE
feat!: Use OTP json module instead of jsx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     name: OTP ${{matrix.otp}}
     strategy:
       matrix:
-        otp: ["24", "25", "26"]
+        otp: ["27", "28"]
       fail-fast: false
     steps:
     - uses: actions/checkout@v4

--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
 %% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 %% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-{deps, [jsx]}.
+{minimum_otp_vsn, "27"}.
 
 {project_plugins, [
     erlfmt

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,1 @@
-{"1.2.0",
-[{<<"jsx">>,{pkg,<<"jsx">>,<<"3.1.0">>},0}]}.
-[
-{pkg_hash,[
- {<<"jsx">>, <<"D12516BAA0BB23A59BB35DCCAF02A1BD08243FCBB9EFE24F2D9D056CCFF71268">>}]},
-{pkg_hash_ext,[
- {<<"jsx">>, <<"0C5CC8FDC11B53CC25CF65AC6705AD39E54ECC56D1C22E4ADB8F5A53FB9427F3">>}]}
-].
+[].

--- a/src/jsonformat.app.src
+++ b/src/jsonformat.app.src
@@ -21,8 +21,7 @@
     {registered, []},
     {applications, [
         kernel,
-        stdlib,
-        jsx
+        stdlib
     ]},
     {licenses, ["MIT"]},
     {links, [{"Github", "https://github.com/kivra/jsonformat/"}]}


### PR DESCRIPTION
This is a breaking change for OTP <27, so it should probably be a major version bump.

