### PR TITLE
chore: Replace archived create-release action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,11 +54,8 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.2
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Create a GitHub release
-      uses: actions/create-release@v1
+    - name: Create GitHub Release
+      shell: bash
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.tag_version.outputs.new_tag }}
-        release_name: Release ${{ steps.tag_version.outputs.new_tag }}
-        body: ${{ steps.tag_version.outputs.changelog }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release create "${{ steps.tag_version.outputs.new_tag }}" --generate-notes


### PR DESCRIPTION
This uses the `gh` cli tool instead, which means we will have one fewer action dependency here.

---

[`actions/create-release`](https://github.com/actions/create-release) is archived since a few years, so we should probably not use it anymore. 